### PR TITLE
[fixed] issue#2, adapt directory separator in Windows

### DIFF
--- a/gulp/doc/gulp-build.js
+++ b/gulp/doc/gulp-build.js
@@ -57,7 +57,7 @@ module.exports = function(options) {
 
         // 如果当前文件为index.md，并且组件有js代码，则生成api
         let jspath = path.join(file.path, '../../index.js');
-        if(file.path.endsWith('/index.md') && fs.existsSync(jspath))
+        if(path.basename(file.path) === 'index.md' && fs.existsSync(jspath))
             data.api = jsAPI.render(jspath, templates['js-api']);
 
         let html;
@@ -70,7 +70,7 @@ module.exports = function(options) {
 
         // 变更路径，修改file
         file.base = file.cwd;
-        file.path = file.path.replace(/demo\/(.+)\.md$/, '$1.html');
+        file.path = file.path.replace(/demo[\\\/](.+)\.md$/, '$1.html');
         file.contents = new Buffer(html);
 
         options.verbose && console.log('[' + chalk.grey(new Date().toLocaleTimeString()) + ']', chalk.blue('Building'), 'doc/' + path.relative(file.base, file.path));

--- a/gulp/test/gulp-concat-import.js
+++ b/gulp/test/gulp-concat-import.js
@@ -19,7 +19,11 @@ module.exports = function(filename, options) {
         if(file.isStream())
             throw new PluginError('gulp-concat-import', 'Streaming not supported');
 
-        pathes.push(file.path);
+        let filePath = file.path;
+        if (path.sep === '\\')
+            filePath = filePath.split(path.sep).join('/');
+
+        pathes.push(filePath);
         lastFile = file;
 
         cb();


### PR DESCRIPTION
由于gulp文件格式中path属性，其路径分隔符是跟随系统的；而森森同学是在POSIX(Mac)下开发，没有考虑到这个问题，因此在Windows下执行时会 #2 这样的问题。

经查，除`gulp/test/gulp-concat-import.js`外，在`gulp/doc/gulp-build.js`中也有相关问题，一并处理了路径分隔符的问题。
